### PR TITLE
(MAINT) Bump version for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 0.2.0
+
+This is a feature release:
+* [SERVER-1773](https://tickets.puppetlabs.com/browse/SERVER-1773) - Add
+  support for bumping versions with qualifiers

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-release-4digit-version "0.1.1-SNAPSHOT"
+(defproject lein-release-4digit-version "0.2.0-SNAPSHOT"
   :description "Leiningen plugin that adds support for 4-digit versions in release/change tasks"
   :url "https://github.com/puppetlabs/lein-release-4digit-version"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This commit bumps the version in preparation for a release. The only new feature is support for bumping qualifiers in 4-digit version numbers